### PR TITLE
Fix GT response so it matches spec

### DIFF
--- a/MoonliteAccelstepperAFMotor.ino
+++ b/MoonliteAccelstepperAFMotor.ino
@@ -161,7 +161,7 @@ void loop(){
 
     // get the current temperature, hard-coded
     if (!strcasecmp(cmd, "GT")) {
-      Serial.print("20#");
+      Serial.print("0020#");
     }
 
     // get the temperature coefficient, hard-coded


### PR DESCRIPTION
The Moonlite protocol spec indicates that the firmware should respond to the get
temperature command "GT" with an ASCII-encoded 16-bit signed integer. Without
this change the INDI moonlight driver is emitting error messages about the
gettemperature command timing out. This is because the INDI driver is waiting to
read 5 characters and it's only getting 3.